### PR TITLE
PBL-15454 Snowy emulator mishandles flash lock protection causing flash issues and apps to not install

### DIFF
--- a/hw/block/pflash_jedec_424.c
+++ b/hw/block/pflash_jedec_424.c
@@ -540,16 +540,10 @@ static void pflash_write(pflash_t *pfl, hwaddr offset,
             pfl->wcycle++;
             break;
         case 0x60:
-            if (cmd == 0xd0) {
-                pfl->wcycle = 0;
-                pfl->status |= 0x80;
-            } else if (cmd == 0x01) {
-                pfl->wcycle = 0;
-                pfl->status |= 0x80;
-            } else if (cmd == 0xff) {
-                goto reset_flash;
-            } else {
-                DPRINTF("%s: Unknown (un)locking command\n", __func__);
+            if (cmd == 0x61) {
+                pfl->cmd = 0x61;
+                pfl->wcycle++;
+            } else if (sector_offset != 0x2aa) {
                 goto reset_flash;
             }
             break;
@@ -651,6 +645,9 @@ static void pflash_write(pflash_t *pfl, hwaddr offset,
                 goto reset_flash;
             }
             break;
+        case 0x61:
+            // Sector Lock Range protection is not implemented
+            goto reset_flash;
         default:
             goto error_flash;
         }


### PR DESCRIPTION
Confirmed that I can now install apps. Qemu now correctly identifies flash lock/unlock sequence for s29 part but does not actually implement sector protection.

Valid lock/unlock seq is
1. cmd 0x60 at offset 0x555
2. cmd 0x60 at offset 0x2aa
3. Sector to unlock at sector start offset

Valid sector lock range seq is
1. cmd 0x60 at offset 0x555
2. cmd 0x60 at offset 0x2aa
3. cmd 0x61 at start sector
4. cmd 0x61 at end sector

I added detection for these two sequences to qemu