### PR TITLE
PBL-25525: QEMU: SPP message from host to target stuck in PebbleControl

### DIFF
--- a/hw/arm/pebble_control.c
+++ b/hw/arm/pebble_control.c
@@ -504,7 +504,7 @@ PebbleControl *pebble_control_create(CharDriverState *chr, Stm32Uart *uart)
 
         // The timer we use to pump more data to the uart
         s->target_send_timer = timer_new_ms(QEMU_CLOCK_HOST,
-                                  (QEMUTimerCB *)pebble_control_forward_to_target, s);
+                                  (QEMUTimerCB *)pebble_control_parse_receive_buffer, s);
 
 
         // Have the UART send writes to us


### PR DESCRIPTION
If data was getting processed through the timer callback and multiple messages would be waiting in the receive buffer, only the first one would get processed.